### PR TITLE
Remove autoApprove from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
   "tekton": {
     "schedule": ["at any time"],
-    "autoApprove": true,
     "automerge": true
   }
 }


### PR DESCRIPTION
`autoApprove` works with GitLab but not with GitHub :cry: 